### PR TITLE
Alarms fix

### DIFF
--- a/drivers/1102011/device.js
+++ b/drivers/1102011/device.js
@@ -25,6 +25,12 @@ function luminanceReportParser(report) {
 
 class StripsMultiSensor extends ZwaveDevice {
   onMeshInit() {
+
+    // Reset alarms on init, since these alarms tend to stick in true state.
+    // The user can then restart the app, to get rid of sticky alarms.
+    this.setCapabilityValue('alarm_water', false);
+    this.setCapabilityValue('alarm_heat', false);
+
     this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL', {
       getOpts: {
         getOnOnline: true,

--- a/drivers/1102011/device.js
+++ b/drivers/1102011/device.js
@@ -51,6 +51,29 @@ class StripsMultiSensor extends ZwaveDevice {
     });
 
     this.registerCapability('alarm_heat', 'NOTIFICATION', {
+      reportParser: report => { 
+
+        // Check Notification Type and event to ensure that the heat alarm should go on/off
+
+        // Heat alarm ON (event 2 = overheat, event 6 = underheat)
+        if (report["Notification Type"] === "Heat" && report["Event"] === 2) {
+          return true
+        }
+
+        // Heat alarm ON (event 2 = overheat, event 6 = underheat)
+        if (report["Notification Type"] === "Heat" && report["Event"] === 6) {
+          return true
+        }
+
+        // Heat alarm OFF
+        if (report["Notification Type"] === "Heat" && report["Event"] === 0) {
+          return false
+        }
+
+        // No matching events, just return null
+        return null;
+
+      },
       getOpts: {
         getOnOnline: true,
       },


### PR DESCRIPTION
Fix of alarms setting off. This happened to me when adding the device, and it wouldnt reset at all. The quickfix is to reset the alarms at onMeshInit(), in case a user wants to reset the alarms, its just to reset the Sensative app.

Also added code which checks for correct event in alarm_heat. This is tested with my own device. It will trigger alarm on/off when notification report is received by device.

I do not have the Sensative Drip, so I couldn't write the same code for that one, I dont know what event is received by that one. Probably the same as in alarm_heat.

@Thorarin 